### PR TITLE
take over maintenance from orphaned package group

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -4,7 +4,7 @@
   <description>Messages for (camera) view controllers</description>
   <author email="adamleeper@gmail.com">Adam Leeper</author>
 
-  <maintainer email="ros-orphaned-packages@googlegroups.com">ROS Orphaned Package Maintainers</maintainer>
+  <maintainer email="evanflynn.msu@gmail.com">Evan Flynn</maintainer>
 
   <license>BSD</license>
   <url type="website">http://ros.org/wiki/view_controller_msgs</url>


### PR DESCRIPTION
this package is [used by `rviz_animated_view_controller`](https://github.com/ros-visualization/rviz_animated_view_controller) so I want to publish it for noetic and then republish it for ROS2 as well