### PR TITLE
add messages to support moving view camera along trajectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ find_package(catkin REQUIRED COMPONENTS genmsg message_generation ${MSG_DEPS})
 
 set(MSG_FILES
 CameraPlacement.msg
+CameraMovement.msg
+CameraTrajectory.msg
 )
 
 add_message_files(DIRECTORY msg FILES ${MSG_FILES})

--- a/msg/CameraMovement.msg
+++ b/msg/CameraMovement.msg
@@ -1,0 +1,26 @@
+# This message defines where to move a camera to and at which speeds.  
+
+# The target pose definition:
+
+# The frame-relative point to move the camera to.
+geometry_msgs/PointStamped eye
+
+# The frame-relative point for the focus (or pivot for an Orbit controller).
+# The camera points into the direction of the focus point at the end of the movement.
+geometry_msgs/PointStamped focus
+
+# The frame-relative vector that maps to "up" in the view plane.
+# In other words, a vector pointing to the top of the camera, in case you want to perform roll movements.
+geometry_msgs/Vector3Stamped up
+
+
+# Defines how long the transition from the current to the target camera pose should take.
+# Movements with a negative transition_duration will be ignored.
+duration transition_duration
+
+# The interpolation speed profile to use during this movement.
+uint8 interpolation_speed
+uint8 RISING    = 0 # Speed of the camera rises smoothly - resembles the first quarter of a sinus wave.
+uint8 DECLINING = 1 # Speed of the camera declines smoothly - resembles the second quarter of a sinus wave.
+uint8 FULL      = 2 # Camera is always at full speed - depending on transition_duration.
+uint8 WAVE      = 3 # RISING and DECLINING concatenated in one movement.

--- a/msg/CameraTrajectory.msg
+++ b/msg/CameraTrajectory.msg
@@ -1,0 +1,34 @@
+# This message defines a trajectory to move a camera along at and several options how to do that.  
+
+# Array of camera poses and interpolation speeds defining a trajectory.
+CameraMovement[] trajectory
+
+# Sets this as the camera attached (fixed) frame before movement.
+# An empty string will leave the attached frame unchanged.
+string target_frame
+
+# A flag indicating if the camera yaw axis is fixed to +Z of the camera attached_frame.
+# (defaults to false)
+bool allow_free_yaw_axis
+
+# The interaction style that should be activated when movement is done.
+uint8 mouse_interaction_mode
+uint8 NO_CHANGE = 0 # Leaves the control style unchanged.
+uint8 ORBIT     = 1 # Activates the Orbit-style controller.
+uint8 FPS       = 2 # Activates the First-Person-Shooter-style controller.
+
+# A flag to enable or disable user interaction.
+# (defaults to false so that interaction is enabled)
+bool interaction_disabled
+
+# If false, the duration of the animated trajectory is equal to the time passed in the real world using ros::WallTime.
+#  This can lead to an inconsistent frame rate of the published camera view images if your computer is not fast enough.
+# If true, the trajectory is rendered frame by frame. This leads to:
+#  -> a consistent frame rate of the published camera view images,
+#  -> a video with the desired trajectory duration when composed of the camera view images,
+#  -> BUT the trajectory might be slower in real time, if your computer is not fast enough. 
+# (defaults to false)
+bool render_frame_by_frame
+
+# Desired frames per second when rendering frame by frame.
+int8 frames_per_second


### PR DESCRIPTION
This pull request is made because of the [issue](https://github.com/AIS-Bonn/rviz_cinematographer/issues/7) suggesting to add the functionality of the [rviz_cinematographer_view_controller](https://github.com/AIS-Bonn/rviz_cinematographer/tree/master/rviz_cinematographer_view_controller) to the [rviz_animated_view_controller](https://github.com/ros-visualization/rviz_animated_view_controller). 

For that, these new message types are needed. 